### PR TITLE
Clean up numbered lists in chapter 1 and 2

### DIFF
--- a/markdown/01-init.md
+++ b/markdown/01-init.md
@@ -4,14 +4,14 @@
 
 1. Before you do anything, run `ls` to print out the contents of this folder.
 
-2. There should be a `welcome.txt` file but nothing else. You can read it by typing `cat welcome.txt`.
+1. There should be a `welcome.txt` file but nothing else. You can read it by typing `cat welcome.txt`.
 
-3. Now run `ls -a`. The `-a` stands for 'all' and makes `ls` show you hidden files as well (hidden filenames start with a `.`)
+1. Now run `ls -a`. The `-a` stands for 'all' and makes `ls` show you hidden files as well (hidden filenames start with a `.`)
 
-3. Run `dat init`. You will be prompted to enter a few pieces of optional information.
+1. Run `dat init`. You will be prompted to enter a few pieces of optional information.
 
-4. Dat should have created a file called `dat.json` as well as a hidden folder called `.dat`.
+1. Dat should have created a file called `dat.json` as well as a hidden folder called `.dat`.
 
-5. Run `ls -a` again and make sure you can see both of these.
+1. Run `ls -a` again and make sure you can see both of these.
 
 `dat.json` is for settings and configuration for this dat. The `.dat` folder is where the dat data actually lives. Note that it's a hidden folder! If something is hidden it generally means you don't need to open up the files inside very often.

--- a/markdown/02-delete-and-listen.md
+++ b/markdown/02-delete-and-listen.md
@@ -8,16 +8,16 @@ In this lesson you will learn the ins-and-outs of deleting a dat repository and 
 
 1. Run `dat clean` to delete the `.dat` folder. This doesn't delete the `dat.json` file.
 
-2. You should now have a `dat.json` but no `.dat` folder. You can check this with `ls -a`.
+1. You should now have a `dat.json` but no `.dat` folder. You can check this with `ls -a`.
 
-3. Try to start the dat http server by running `dat listen`. You should get an error `Error: There is no dat here` So even though we have a `dat.json` file that doesn't make it a valid dat repository. 
+1. Try to start the dat http server by running `dat listen`. You should get an error `Error: There is no dat here` So even though we have a `dat.json` file that doesn't make it a valid dat repository.
 
-4. Do `dat init` again. It will go through the prompt again, but with the existing values from `dat.json` as defaults.
+1. Do `dat init` again. It will go through the prompt again, but with the existing values from `dat.json` as defaults.
 
-5. Now try to start the dat server again by running `dat listen`. This time it should succeed!
+1. Now try to start the dat server again by running `dat listen`. This time it should succeed!
 
-6. Try viewing your dat server in a new browser tab. You can get the address of your server from `welcome.txt`. Remember to open it in a new tab!
+1. Try viewing your dat server in a new browser tab. You can get the address of your server from `welcome.txt`. Remember to open it in a new tab!
 
-6. To stop the dat server enter `CTRL + c` (hold down `CTRL` and then `c` simultaneously). This is a terminal command that stops the current program.
+1. To stop the dat server enter `CTRL + c` (hold down `CTRL` and then `c` simultaneously). This is a terminal command that stops the current program.
 
 That's all there is to it!


### PR DESCRIPTION
The last two items in chapter 2 had the same number. But instead of just
incrementing the last item, I've changed all lists to just use 1's. This
will allow markdown to handle the numbering automatically and make it
easier to add and rearrange items in the future.
