### PR TITLE
fix minor typos in live syncing and beaker browser sections

### DIFF
--- a/markdown/04-live.md
+++ b/markdown/04-live.md
@@ -12,7 +12,7 @@ What happens if you make changes to the remote file while your local machine is 
 
 Watch what happens in your **local terminal** window as you type. 
 
-Since this is a tiny text time, the updates will download extremely fast. Your **local terminal** window will look something like this:
+Since this is a tiny text file, the updates will download extremely fast. Your **local terminal** window will look something like this:
 ```
 1 connection | Download 445 KB/s Upload 0 B/s
 

--- a/markdown/100-beaker.md
+++ b/markdown/100-beaker.md
@@ -12,7 +12,7 @@ If you haven't added an index.html, Beaker should show you something like this:
 
 ![Beaker-image](/img/beaker-screenshot-1.png)
 
-If you've added an index.htl file, it will render the html and look more like this:
+If you've added an index.html file, it will render the html and look more like this:
 
 ![Beaker-image](/img/Beaker-screenshot-2.png)
 


### PR DESCRIPTION
Also, in markdown/102-desktop-application.md, the link to the screenshot of the desktop client is broken. Cheers