### PR TITLE
Copy consistency when referring to the terminal

### DIFF
--- a/guide/01-install.html
+++ b/guide/01-install.html
@@ -20,7 +20,7 @@
 <p>If you run into problems, you can view more detailed installation instructions <a href="https://github.com/datproject/dat/blob/master/README.md#installing-the--dat-command-line-tool">here</a>.</p>
 <p>You&#39;ll also need a Terminal application on your local computer. If you&#39;re using Windows, you should use the <strong>Git Shell</strong> app as your terminal. It is installed with <a href="http://desktop.github.com">GitHub Desktop</a>. In Mac and Linux you can use the app <strong>Terminal</strong>, which is already on your computer.</p>
 <p>If you&#39;ve never used the command line before, check out <a href="http://rik.smith-unna.com/command_line_bootcamp/?id=bfv5p9l1w5g">Command Line Bootcamp</a> to get comfortable navigating your computer via the command line. </p>
-<p>Once you have downloaded npm, install dat on your local machine. Type the following in your <strong>local terminal</strong>:</p>
+<p>Once you have downloaded npm, install dat on your local machine. Type the following in your terminal:</p>
 <pre><code>npm install -g dat
 </code></pre><p>This means that dat is now installed on your system:</p>
 <pre><code>$ dat

--- a/guide/02-link.html
+++ b/guide/02-link.html
@@ -26,14 +26,14 @@ dat://5a4575c632d1a573...
 </code></pre><p>Behind the scenes dat created a new hidden folder called <code>.dat</code> in your test folder. The appearance of the <code>.dat</code> folder means that everything in this directory can now be versioned with Dat. </p>
 <p>As long as the <code>dat share</code> process stays open and running the data will be available via the global Dat decentralized network to anyone who has that link. The link is secret and unguessable. Only people who you share the link with will be able to access your dat.</p>
 <h2 id="downloading">Downloading</h2>
-<p>First, copy the dat link from the source terminal. Windows users beware - please right-click to copy, as <code>cntrl-C</code> will quit dat and dat needs to keep running.</p>
+<p>First, copy the dat link from the source terminal. Windows users beware - please right-click to copy, as <code>control-C</code> will quit dat and dat needs to keep running.</p>
 <p>If you are doing this tutorial using a single computer, open up a second terminal window, we will refer to this second one as the <strong>destination</strong> terminal. The first one is the <strong>source</strong> terminal.</p>
 <p>If you are doing this tutorial with a second computer, then use the second computer as the <strong>destination</strong>. Find a way to send them the dat link (email, text message).</p>
 <p>On the <strong>destination</strong> terminal: Move to a directory where you&#39;d like to add these files. To download the files from the source, type <code>dat clone</code> followed by the link <code>dat://</code>, and a folder name like <code>try-dat</code>. </p>
 <p>The full command should look like this:</p>
 <pre><code>dat clone dat://replace-with-your-dat-link-here try-dat
 </code></pre><p>The files will be downloaded to the destination, to the current working directory, into a folder called <code>try-dat</code>. Take a minute now to check that the files on your destination match the files from the source.</p>
-<p><strong>Lastly</strong>, on the source, type <code>control-C</code> to stop running dat. You should now be back to the command prompt on both terminals.</p>
+<p><strong>Lastly</strong>, on the <strong>source</strong> terminal, type <code>control-C</code> to stop running dat. You should now be back to the command prompt on both terminals.</p>
 
         <div class="navlinks">
           <a class="nextp button" href="03-modify.html">OK, next! &raquo;</a>

--- a/guide/02-link.html
+++ b/guide/02-link.html
@@ -26,7 +26,7 @@ dat://5a4575c632d1a573...
 </code></pre><p>Behind the scenes dat created a new hidden folder called <code>.dat</code> in your test folder. The appearance of the <code>.dat</code> folder means that everything in this directory can now be versioned with Dat. </p>
 <p>As long as the <code>dat share</code> process stays open and running the data will be available via the global Dat decentralized network to anyone who has that link. The link is secret and unguessable. Only people who you share the link with will be able to access your dat.</p>
 <h2 id="downloading">Downloading</h2>
-<p>First, copy the dat link from the source terminal. Windows users beware - please right-click to copy, as <code>control-C</code> will quit dat and dat needs to keep running.</p>
+<p>First, copy the dat link from the <strong>source</strong> terminal. Windows users beware - please right-click to copy, as <code>control-C</code> will quit dat and dat needs to keep running.</p>
 <p>If you are doing this tutorial using a single computer, open up a second terminal window, we will refer to this second one as the <strong>destination</strong> terminal. The first one is the <strong>source</strong> terminal.</p>
 <p>If you are doing this tutorial with a second computer, then use the second computer as the <strong>destination</strong>. Find a way to send them the dat link (email, text message).</p>
 <p>On the <strong>destination</strong> terminal: Move to a directory where you&#39;d like to add these files. To download the files from the source, type <code>dat clone</code> followed by the link <code>dat://</code>, and a folder name like <code>try-dat</code>. </p>

--- a/guide/03-modify.html
+++ b/guide/03-modify.html
@@ -14,7 +14,7 @@
         <p><a href="index.html">table of contents</a></p>
       <h1 id="editing-sharing-data">Editing &amp; sharing data</h1>
 <p>Now you have a copy of the files on your destination a folder called <code>try-dat</code>! But what happens if the contents of the files change? Let&#39;s find out.</p>
-<p>On the <strong>source</strong> create a new file called <code>welcome.txt</code> and open it in your favorite text editor app (such as TextEdit or Sublime Text). Make some changes to the text in the file. Once you&#39;ve edited it, save the file. The file on the source will no longer match the one on the destination. To rectify this and sync the new changes to the destination copy, run <code>dat share</code> again on the source.</p>
+<p>On the <strong>source</strong> terminal, create a new file called <code>welcome.txt</code> and open it in your favorite text editor app (such as TextEdit or Sublime Text). Make some changes to the text in the file. Once you&#39;ve edited it, save the file. The file on the source will no longer match the one on the destination. To rectify this and sync the new changes to the destination copy, run <code>dat share</code> again on the source.</p>
 <p>Type the following in the <strong>source</strong> terminal:</p>
 <pre><code>$ dat share
 </code></pre><p>This will create a link, that looks like <code>dat://...</code>.  Your output in the <strong>source</strong> terminal will look something like this:</p>

--- a/guide/04-live.html
+++ b/guide/04-live.html
@@ -17,7 +17,7 @@
 <p>Notice that your <strong>source</strong> terminal window says:</p>
 <pre><code>dat synced, waiting for updates.
 </code></pre><p>What happens if you make changes to the source file while your destination is watching? On the <strong>source</strong> side, edit the <code>welcome.txt</code> rapidly, saving after each edit in your text editor program.</p>
-<p>Watch what happens in your <strong>destionation terminal</strong> window as you save. </p>
+<p>Watch what happens in your <strong>destination terminal</strong> window as you save.</p>
 <p>Since this is a tiny text time, the updates will download extremely fast. Your <strong>source terminal</strong> window will look something like this:</p>
 <pre><code>1 connection | Download 445 KB/s Upload 0 B/s
 

--- a/guide/05-website.html
+++ b/guide/05-website.html
@@ -15,9 +15,9 @@
       <h1 id="hosting-a-website">Hosting a website</h1>
 <p>We&#39;ve covered sharing, syncing, and live syncing of data. But what about sharing via the web? We can create a Dat link that can be viewed in any browser. Dat has an http server that can be turned on by adding <code>--http$PORT_XX</code>, where XX is specific to the server port. </p>
 <p>To share your data via the web, create a file called <code>index.html</code> using the command <code>touch</code>. 
-Type the following into the <strong>virtual terminal</strong>: </p>
+Type the following into the terminal: </p>
 <p><code>touch index.html</code></p>
-<p>You will see a new file, <code>index.html</code>, has been added to the directory on the virtual server. </p>
+<p>You will see a new file, <code>index.html</code>, has been added to the directory. </p>
 <p>Let&#39;s make it fun! Use the test editor in the browser to add to the new <code>index.html</code>. Edit it and add some stuff in your html. Here&#39;s a silly template to get you started. </p>
 <pre><code>&lt;!DOCTYPE html&gt;
 &lt;html&gt;
@@ -33,7 +33,7 @@ Type the following into the <strong>virtual terminal</strong>: </p>
   &lt;img id=&quot;rickroll&quot; src=&quot;https://media.giphy.com/media/13tTN4ccM3R6us/giphy.gif&quot;/&gt;  
 &lt;/body&gt;
 &lt;/html&gt;
-</code></pre><p>To share this, type the following in the <strong>source terminal</strong>:</p>
+</code></pre><p>To share this, type the following in the terminal:</p>
 <p><code>dat share --http=8080</code> </p>
 <p>Check out your new website at <a href="http://localhost:8080!">http://localhost:8080!</a></p>
 <p>When you modify file, the site will update when you refresh the browser window. Pretty cool, huh?</p>

--- a/guide/06-dat-git-partial.html
+++ b/guide/06-dat-git-partial.html
@@ -15,13 +15,13 @@
       <h1 id="downloading-a-partial-dataset-from-git">Downloading a partial dataset from git</h1>
 <p>Here&#39;s an example of hosting code on Github that includes a link to a Dat dataset. This Github repo contains a <code>dat.json</code> file, which contains the Dat link (dat://...) for the dataset as well as other metadata about these data. </p>
 <p>The author has included a <code>.datdownload</code> file which specifies which files users will download by default. Without this, all files would be downloaded upon dat cloning this repository. You can imagine a scenario where a larger dataset is availble, but only segments of it are required to reproduce an analysis. Or a dataset that won&#39;t fit in git, but fits in dat. Because this author has a <code>dat.json</code> file in their git repository, you don&#39;t need to work with their Dat link. In this exercise, you will clone the repository with git and then access the data with dat.</p>
-<p>To clone the repository to your local machine using git, type the following in your <strong>local terminal</strong>:</p>
+<p>To clone the repository to your local machine using git, type the following in your terminal:</p>
 <pre><code>git clone https://github.com/joehand/dat-git-example.git
-</code></pre><p>Now you have a copy of <code>dat-git-example</code> that includes text and code files, but none of the data files. Check the <code>index.html</code> to see that the pictures are missing by typing the following in your <strong>local terminal</strong>:</p>
+</code></pre><p>Now you have a copy of <code>dat-git-example</code> that includes text and code files, but none of the data files. Check the <code>index.html</code> to see that the pictures are missing by typing the following in your terminal:</p>
 <pre><code>open index.html
-</code></pre><p>To get the data, run <code>dat clone --empty</code> to fetch the <code>.dat</code> metadata (but none of the files). Type the following in your <strong>source terminal</strong>: </p>
+</code></pre><p>To get the data, run <code>dat clone --empty</code> to fetch the <code>.dat</code> metadata (but none of the files). Type the following in your terminal: </p>
 <pre><code>dat clone ./dat-git-example --empty
-</code></pre><p>Then sync to get the files, specified by the <code>.datdownload</code>, type the following in your <strong>source terminal</strong>:</p>
+</code></pre><p>Then sync to get the files, specified by the <code>.datdownload</code>, type the following in your terminal:</p>
 <pre><code>dat sync ./dat-git-example
 </code></pre><p>You should now have downloaded both the code (<code>index.html</code>) and the data files that were specificed by the <code>.datdownload</code> file. </p>
 


### PR DESCRIPTION
An attempt to get us to refer to the terminal consistently in the copy to avoid causing confusion by using different terms when targeting the same terminal instance/session.

Fixes #48 